### PR TITLE
Support many files

### DIFF
--- a/s3deploy.rb
+++ b/s3deploy.rb
@@ -11,8 +11,7 @@ require 'time'
 # --------------------------
 
 def log_fail(message)
-  puts
-  puts "\e[31m#{message}\e[0m"
+  puts "\n\e[31m#{message}\e[0m"
   exit(1)
 end
 
@@ -21,8 +20,7 @@ def log_warn(message)
 end
 
 def log_info(message)
-  puts
-  puts "\e[34m#{message}\e[0m"
+  puts "\n\e[34m#{message}\e[0m"
 end
 
 def log_details(message)
@@ -34,15 +32,12 @@ def log_done(message)
 end
 
 def s3_object_uri_for_bucket_and_path(bucket_name, path_in_bucket)
-  return "s3://#{bucket_name}/#{path_in_bucket}"
+  "s3://#{bucket_name}/#{path_in_bucket}"
 end
 
 def public_url_for_bucket_and_path(bucket_name, bucket_region, path_in_bucket)
-  if bucket_region.to_s == '' || bucket_region.to_s == 'us-east-1'
-    return "https://s3.amazonaws.com/#{bucket_name}/#{path_in_bucket}"
-  end
-
-  return "https://s3-#{bucket_region}.amazonaws.com/#{bucket_name}/#{path_in_bucket}"
+  return "https://s3.amazonaws.com/#{bucket_name}/#{path_in_bucket}" if bucket_region.to_s.empty? || bucket_region == 'us-east-1'
+  "https://s3-#{bucket_region}.amazonaws.com/#{bucket_name}/#{path_in_bucket}"
 end
 
 def export_output(out_key, out_value)
@@ -54,7 +49,7 @@ def export_output(out_key, out_value)
 end
 
 def do_s3upload(sourcepth, full_destpth, aclstr)
-  return system(%Q{aws s3 cp "#{sourcepth}" "#{full_destpth}" --acl "#{aclstr}"})
+  system(%Q{aws s3 cp "#{sourcepth}" "#{full_destpth}" --acl "#{aclstr}"})
 end
 
 # -----------------------
@@ -73,23 +68,8 @@ options = {
   acl: ENV['file_access_level']
 }
 
-#
-# Print options
 log_info('Configs:')
-log_details("* file_path: #{options[:file]}")
-log_details("* app_slug: #{options[:app_slug]}")
-log_details("* build_slug: #{options[:build_slug]}")
-
-log_details('* aws_access_key: ') if options[:access_key].to_s == ''
-log_details('* aws_access_key: ***') unless options[:access_key].to_s == ''
-
-log_details('* aws_secret_key: ') if options[:secret_key].to_s == ''
-log_details('* aws_secret_key: ***') unless options[:secret_key].to_s == ''
-
-log_details("* bucket_name: #{options[:bucket_name]}")
-log_details("* bucket_region: #{options[:bucket_region]}")
-log_details("* path_in_bucket: #{options[:path_in_bucket]}")
-log_details("* file_access_level: #{options[:acl]}")
+options.each { |key, value| log_details("* #{key}: #{value || 'N/A'}") }
 
 status = 'success'
 begin
@@ -160,9 +140,8 @@ begin
   log_details("* File: #{public_url_file}")
 rescue => ex
   status = 'failed'
-  log_fail("#{ex}")
+  log_fail(ex.message)
 ensure
   export_output('S3_UPLOAD_STEP_STATUS', status)
-  puts
-  log_done("#{status}")
+  log_done("Status: #{status}")
 end

--- a/s3deploy.rb
+++ b/s3deploy.rb
@@ -48,10 +48,10 @@ def export_output(out_key, out_value)
   end
 end
 
-def upload_file_to_s3(file, base_path_in_bucket, bucket_name, acl_arg)
+def upload_file_to_s3(file, base_path_in_bucket, bucket_name, acl_arg, options)
   file_path_in_bucket = "#{base_path_in_bucket}/#{File.basename(file)}"
   file_full_s3_path = s3_object_uri_for_bucket_and_path(bucket_name, file_path_in_bucket)
-  public_url_file = public_url_for_bucket_and_path(options[:bucket_name], options[:bucket_region], file_path_in_bucket)
+  public_url_file = public_url_for_bucket_and_path(bucket_name, options[:bucket_region], file_path_in_bucket)
   log_info("Deploy info for file #{file}:")
   log_details("* Access Level: #{options[:acl]}")
   log_details("* File: #{public_url_file}")
@@ -120,7 +120,7 @@ begin
   options[:files].each do |file|
     log_info("Uploading file #{file} to S3...")
     fail "File not found: #{file}" unless File.exist?(file)
-    @public_urls << upload_file_to_s3(file, base_path_in_bucket, options[:bucket_name], acl_arg)
+    @public_urls << upload_file_to_s3(file, base_path_in_bucket, options[:bucket_name], acl_arg, options)
   end
 
   if @public_urls.size == 1

--- a/s3deploy.rb
+++ b/s3deploy.rb
@@ -68,8 +68,12 @@ end
 # -----------------------
 
 # `file_paths` should be a comma-separated string of file paths.
+if ENV['file_path']
+  log_warn("ENV['file_path'] is deprecated and will be removed in a future release. Please use ENV['file_paths'] instead.")
+end
+
 options = {
-  files: (ENV['file_paths'] || '').split(',').map(&:strip),
+  files: (ENV['file_paths'] || ENV['file_path'] || '').split(',').map(&:strip),
   app_slug: ENV['app_slug'],
   build_slug: ENV['build_slug'],
   access_key: ENV['aws_access_key'],

--- a/tests/step_test.sh
+++ b/tests/step_test.sh
@@ -14,7 +14,7 @@ function print_and_do_command {
 }
 
 function inspect_test_result {
-  if [ $1 -eq 0 ]; then
+  if [ "$1" -eq 0 ]; then
     test_results_success_count=$[test_results_success_count + 1]
   else
     test_results_error_count=$[test_results_error_count + 1]
@@ -122,6 +122,9 @@ test_results_error_count=0
   export bucket_name="123"
   export file_path="$test_file_path"
   export bucket_region="eu-west-1"
+  export app_slug="test"
+  export build_slug="test"
+  export file_access_level="private"
 
   expect_success "aws_access_key environment variable should be set" is_not_empty "$aws_access_key"
   expect_success "aws_secret_key environment variable should be set" is_not_empty "$aws_secret_key"


### PR DESCRIPTION
###Description

The step was missing the ability to support many files. In this PR, we add support for it by adding a new option file_paths.

We also keep supporting file_path and add a warning that it is deprecated and will be removed in the future. This will ensure that current users' workflows are not broken when updating to the newer step.